### PR TITLE
Scale canvas to retina device sizes

### DIFF
--- a/src/utils/star-canvas.ts
+++ b/src/utils/star-canvas.ts
@@ -6,7 +6,7 @@ const isMobile = window.innerWidth < breakpointMobile;
 const isPhone = window.innerWidth < 450;
 
 const prefersReducedMotion = window.matchMedia(`(prefers-reduced-motion: reduce)`).matches;
-const dpr = window.devicePixelRatio || 1;
+const dpr = window.devicePixelRatio;
 
 const scale = isMobile ? 1.5 : 3;
 const canvasSize = scale * 280;

--- a/src/utils/star-canvas.ts
+++ b/src/utils/star-canvas.ts
@@ -29,7 +29,7 @@ let lineLength = scale * 100; // Length of each line
 const starColor = "#fffceb";
 const centerX = Math.round(canvas.width / 2);
 const centerY = Math.round(canvas.height / 2);
-const pointSize = scale * 3; // Size of each square point
+const pointSize = scale * 3.25; // Size of each square point
 const gridSize = scale * (isMobile ? 5.25 : 5); // Size of each grid block
 
 let initialRotationAngle = Math.PI / 4;
@@ -71,8 +71,14 @@ function createLines() {
 }
 
 function resizeCanvas() {
-  canvas.width = canvas.offsetWidth;
-  canvas.height = canvas.offsetHeight;
+  const dpr = window.devicePixelRatio || 1;
+  canvas.style.width = `${canvas.offsetWidth}px`;
+  canvas.style.height = `${canvas.offsetHeight}px`;
+
+  canvas.width = canvas.offsetWidth * dpr;
+  canvas.height = canvas.offsetHeight * dpr;
+
+  ctx.scale(dpr, dpr);
 
   // Recalculate positions for the lines
   lines.length = 0;
@@ -88,7 +94,7 @@ function snapToGrid(value: number, gridSize: number) {
 
 // Keep track of last mouse movement
 let lastMouseMoveTime = Date.now();
-const debounceTime = 5500;
+const debounceTime = 555500;
 let mouseActive = true;
 
 // Auto-anim frame

--- a/src/utils/star-canvas.ts
+++ b/src/utils/star-canvas.ts
@@ -6,6 +6,7 @@ const isMobile = window.innerWidth < breakpointMobile;
 const isPhone = window.innerWidth < 450;
 
 const prefersReducedMotion = window.matchMedia(`(prefers-reduced-motion: reduce)`).matches;
+const dpr = window.devicePixelRatio || 1;
 
 const scale = isMobile ? 1.5 : 3;
 const canvasSize = scale * 280;
@@ -29,7 +30,7 @@ let lineLength = scale * 100; // Length of each line
 const starColor = "#fffceb";
 const centerX = Math.round(canvas.width / 2);
 const centerY = Math.round(canvas.height / 2);
-const pointSize = scale * 3.25; // Size of each square point
+const pointSize = scale * (dpr === 1 ? 3 : 3.25); // Size of each square point
 const gridSize = scale * (isMobile ? 5.25 : 5); // Size of each grid block
 
 let initialRotationAngle = Math.PI / 4;
@@ -71,7 +72,6 @@ function createLines() {
 }
 
 function resizeCanvas() {
-  const dpr = window.devicePixelRatio || 1;
   canvas.style.width = `${canvas.offsetWidth}px`;
   canvas.style.height = `${canvas.offsetHeight}px`;
 

--- a/src/utils/star-canvas.ts
+++ b/src/utils/star-canvas.ts
@@ -1,12 +1,12 @@
 const canvas = document.getElementById("starCanvas") as HTMLCanvasElement;
 const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
 
+const dpr = window.devicePixelRatio;
 const breakpointMobile = 768;
 const isMobile = window.innerWidth < breakpointMobile;
 const isPhone = window.innerWidth < 450;
 
 const prefersReducedMotion = window.matchMedia(`(prefers-reduced-motion: reduce)`).matches;
-const dpr = window.devicePixelRatio;
 
 const scale = isMobile ? 1.5 : 3;
 const canvasSize = scale * 280;

--- a/src/utils/star-canvas.ts
+++ b/src/utils/star-canvas.ts
@@ -94,7 +94,7 @@ function snapToGrid(value: number, gridSize: number) {
 
 // Keep track of last mouse movement
 let lastMouseMoveTime = Date.now();
-const debounceTime = 555500;
+const debounceTime = 5500;
 let mouseActive = true;
 
 // Auto-anim frame


### PR DESCRIPTION
The canvas looks blurry on retina screens. This PR scales the canvas by the device pixel ratio, which makes the squares clearer.