### PR TITLE
Make hero 90vh instead of 100vh

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,7 +15,7 @@ export const prerender = true;
 >
   <div class="flex flex-col min-w-screen font-mono">
     <div
-      class="flex flex-col md:flex-row items-center justify-start md:h-screen mx-2 xl:ml-32 lg:ml-20 md:ml-16 my-10 md:my-0"
+      class="flex flex-col md:flex-row items-center justify-start md:h-[92vh] lg:h-[90vh] mx-2 xl:ml-32 lg:ml-20 md:ml-16 my-10 md:my-0"
     >
       <div class="flex flex-col justify-center items-start w-11/12 md:w-1/2">
         <h1
@@ -86,11 +86,12 @@ export const prerender = true;
   </div>
 
   <div class="bg-white text-red">
+  <div class="w-full flex justify-center my-12 text-4xl">✷</div>
     <div
       class="flex flex-col items-start md:items-center gap-y-4 justify-center w-11/12 sm:w-full max-w-5xl mx-auto sm:px-12"
     >
-      <div class="font-mono mt-8 md:mt-24 flex flex-col gap-4">
-        <h1 class="text-4xl md:text-7xl lg:text-8xl font-doto">WHAT IS THIS?</h1>
+      <div class="font-mono flex flex-col gap-4">
+        <h1 class="text-4xl md:text-7xl md:text-center lg:text-8xl font-doto">WHAT IS THIS?</h1>
         <div class="max-w-3xl flex flex-col gap-4">
           <p>
             BURST ✷ is a 4-hour pop-up gallery exhibition of creative technical

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,7 +15,7 @@ export const prerender = true;
 >
   <div class="flex flex-col min-w-screen font-mono">
     <div
-      class="flex flex-col md:flex-row items-center justify-start md:min-h-[92vh] lg:h-[90vh] mx-2 xl:ml-32 lg:ml-20 md:ml-16 my-10 md:my-0"
+      class="flex flex-col md:flex-row items-center justify-start md:min-h-[92vh] tall:h-[90vh] mx-2 xl:ml-32 lg:ml-20 md:ml-16 my-10 md:my-0"
     >
       <div class="flex flex-col justify-center items-start w-11/12 md:w-1/2">
         <h1

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,7 +15,7 @@ export const prerender = true;
 >
   <div class="flex flex-col min-w-screen font-mono">
     <div
-      class="flex flex-col md:flex-row items-center justify-start md:h-[92vh] lg:h-[90vh] mx-2 xl:ml-32 lg:ml-20 md:ml-16 my-10 md:my-0"
+      class="flex flex-col md:flex-row items-center justify-start md:min-h-[92vh] lg:h-[90vh] mx-2 xl:ml-32 lg:ml-20 md:ml-16 my-10 md:my-0"
     >
       <div class="flex flex-col justify-center items-start w-11/12 md:w-1/2">
         <h1

--- a/src/utils/star-canvas.ts
+++ b/src/utils/star-canvas.ts
@@ -8,7 +8,7 @@ const isPhone = window.innerWidth < 450;
 
 const prefersReducedMotion = window.matchMedia(`(prefers-reduced-motion: reduce)`).matches;
 
-const scale = isMobile ? 1.5 : 3;
+const scale = isMobile ? 1.5 : 2.75;
 const canvasSize = scale * 280;
 canvas.width = isPhone ? window.innerWidth : canvasSize
 canvas.height = isPhone ? window.innerWidth : canvasSize

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,6 +14,9 @@ const config = {
         white: "#fffceb",
         red: "#E6002A"
       },
+      screens: {
+        'tall': { 'raw': '(min-width: 1024px) and (min-height: 700px)' }
+      }
     },
   },
   plugins: [],


### PR DESCRIPTION
Heard some feedback that people didn't know they could scroll for more info after the hero. I don't think this is a huge issue, but when I experimented with 90vh, I liked how it looked, so I'm shipping a 90vh hero.